### PR TITLE
Fix path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ catkin build hector_uav_msgs
 Run the simulator with
 
 ```
-source ~/drone_racing_ws/devel.setup/bash
+source ~/drone_racing_ws/devel/setup.bash
 roslaunch tiers_drone_racing hector_dronerace.launch
 ```
 
 Start the motors in another terminal window/tab:
 ```
-source ~/drone_racing_ws/devel.setup/bash
+source ~/drone_racing_ws/devel/setup.bash
 rosservice call /enable_motors "enable: true"
 ```
 


### PR DESCRIPTION
Ran the commands in the README. These lines errored because of a typo.

Fixed the typos.